### PR TITLE
Do not try installing distribute every time setup.py runs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,12 @@
 import os
 import re
 
-from distribute_setup import use_setuptools; use_setuptools()
+try:
+    import setuptools
+except ImportError:
+    from distribute_setup import use_setuptools
+    use_setuptools()
+
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
Make distribute installation optional (if setuptools/distribute is already installed, do not call `use_setuptools`)

My problem is that I have setuptools installed instead of distribute, and I do not need to install distribute in order to use cssmin. So I added a try/except for setuptools package, so it is not mandatory to always install distribute.
