### PR TITLE
Removing the space before and after the plus sign causes some functions to break

### DIFF
--- a/src/cssmin.py
+++ b/src/cssmin.py
@@ -71,7 +71,7 @@ def remove_unnecessary_whitespace(css):
 
     css = pseudoclasscolon(css)
     # Remove spaces from before things.
-    css = re.sub(r"\s+([!{};:>+\(\)\],])", r"\1", css)
+    css = re.sub(r"\s+([!{};:>\(\)\],])", r"\1", css)
 
     # If there is a `@charset`, then only allow one, and move to the beginning.
     css = re.sub(r"^(.*)(@charset \"[^\"]*\";)", r"\2\1", css)
@@ -85,7 +85,7 @@ def remove_unnecessary_whitespace(css):
     css = css.replace('___PSEUDOCLASSCOLON___', ':')
 
     # Remove spaces from after things.
-    css = re.sub(r"([!{}:;>+\(\[,])\s+", r"\1", css)
+    css = re.sub(r"([!{}:;>\(\[,])\s+", r"\1", css)
 
     return css
 


### PR DESCRIPTION
try to run the below code in command line:

```
echo "a{right: calc(50% + 16px);}" | cssmin
```

you will get 

```
a{right:calc(50%+16px)}
```

Apply the (fix) and run.

```
echo "a{right: calc(50% + 16px);}" | cssmin
```

you will get 

```
a{right:calc(50% + 16px)}
```

I am not sure how much this pull request breaks, but i am guessing it should not, i have done some testing and seems to work fine
