### PR TITLE
Fixed the spaces issue with calc() and sum operation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 
 setup(
     name             = 'cssmin',
-    version          = '0.2.0',
+    version          = '0.2.1',
     author           = "Zachary Voase",
     author_email     = "zacharyvoase@me.com",
     url              = 'http://github.com/zacharyvoase/cssmin',

--- a/src/cssmin.py
+++ b/src/cssmin.py
@@ -10,7 +10,7 @@ except ImportError:
 import re
 
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 
 
 def remove_comments(css):

--- a/src/cssmin.py
+++ b/src/cssmin.py
@@ -71,7 +71,7 @@ def remove_unnecessary_whitespace(css):
 
     css = pseudoclasscolon(css)
     # Remove spaces from before things.
-    css = re.sub(r"\s+([!{};:>+\(\)\],])", r"\1", css)
+    css = re.sub(r"\s+([!{};:>\(\)\],])", r"\1", css)
 
     # If there is a `@charset`, then only allow one, and move to the beginning.
     css = re.sub(r"^(.*)(@charset \"[^\"]*\";)", r"\2\1", css)
@@ -85,7 +85,7 @@ def remove_unnecessary_whitespace(css):
     css = css.replace('___PSEUDOCLASSCOLON___', ':')
 
     # Remove spaces from after things.
-    css = re.sub(r"([!{}:;>+\(\[,])\s+", r"\1", css)
+    css = re.sub(r"([!{}:;>\(\[,])\s+", r"\1", css)
 
     return css
 


### PR DESCRIPTION
If you have some css code like:

```css
calc(50px + 2%)
```

The cssmin should keep the spaces around the plus signal because otherwhise (50px+2%) is not w3c valid.